### PR TITLE
Add Mullvad VPN and 1Password to build script

### DIFF
--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -157,16 +157,8 @@ dnf5 -y copr enable yalter/niri-git
 dnf5 install -yq niri wl-clipboard swayidle mako
 
 # VPN and password manager
-rpm --import https://repo.mullvad.net/rpm/mullvad-keyring.asc
-cat <<'EOF' >/etc/yum.repos.d/mullvad.repo
-[mullvad]
-name=Mullvad VPN
-baseurl=https://repo.mullvad.net/rpm/stable/$basearch
-enabled=1
-gpgcheck=1
-repo_gpgcheck=1
-gpgkey=https://repo.mullvad.net/rpm/mullvad-keyring.asc
-EOF
+rpm --import https://repository.mullvad.net/rpm/mullvad-keyring.asc
+dnf5 config-manager addrepo --from-repofile=https://repository.mullvad.net/rpm/stable/mullvad.repo
 dnf5 install -yq mullvad-vpn
 
 rpm --import https://downloads.1password.com/linux/keys/1password.asc

--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -156,6 +156,31 @@ rm -rf helix-driver
 dnf5 -y copr enable yalter/niri-git
 dnf5 install -yq niri wl-clipboard swayidle mako
 
+# VPN and password manager
+cat <<'EOF' >/etc/yum.repos.d/mullvad.repo
+[mullvad]
+name=Mullvad VPN
+baseurl=https://repo.mullvad.net/rpm/stable/\$basearch
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://repo.mullvad.net/rpm/mullvad-keyring.asc
+EOF
+dnf5 install -yq mullvad-vpn
+
+rpm --import https://downloads.1password.com/linux/keys/1password.asc
+cat <<'EOF' >/etc/yum.repos.d/1password.repo
+[1password]
+name=1Password Stable Channel
+baseurl=https://downloads.1password.com/linux/rpm/stable/\$basearch
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+type=rpm-md
+gpgkey=https://downloads.1password.com/linux/keys/1password.asc
+EOF
+dnf5 install -yq 1password
+
 # Remove rust and install rustup instead
 dnf5 remove -yq cargo rust-analyzer rustfmt clippy
 dnf5 install -yq rustup

--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -157,10 +157,11 @@ dnf5 -y copr enable yalter/niri-git
 dnf5 install -yq niri wl-clipboard swayidle mako
 
 # VPN and password manager
+rpm --import https://repo.mullvad.net/rpm/mullvad-keyring.asc
 cat <<'EOF' >/etc/yum.repos.d/mullvad.repo
 [mullvad]
 name=Mullvad VPN
-baseurl=https://repo.mullvad.net/rpm/stable/\$basearch
+baseurl=https://repo.mullvad.net/rpm/stable/$basearch
 enabled=1
 gpgcheck=1
 repo_gpgcheck=1
@@ -172,7 +173,7 @@ rpm --import https://downloads.1password.com/linux/keys/1password.asc
 cat <<'EOF' >/etc/yum.repos.d/1password.repo
 [1password]
 name=1Password Stable Channel
-baseurl=https://downloads.1password.com/linux/rpm/stable/\$basearch
+baseurl=https://downloads.1password.com/linux/rpm/stable/$basearch
 enabled=1
 gpgcheck=1
 repo_gpgcheck=1


### PR DESCRIPTION
## Summary
- add Mullvad RPM repository and install the Mullvad VPN client during the image build
- import the 1Password signing key, configure its repository, and install the 1Password desktop app

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ef604ba6b483308f97dddfc0622b4a